### PR TITLE
Implemented updateConfig method

### DIFF
--- a/src/ircbot.js
+++ b/src/ircbot.js
@@ -12,8 +12,21 @@ module.exports = class IRCBot {
         
     };
     
-    updateConfig () {
+    /*
+    * Wrapper around the extend module for updating
+    * the bot config to make it clear what is happening 
+    * in plugins when they update the config. This also 
+    * allows for a central place to add hooks into the 
+    * config update process.
+    */
+    updateConfig (newConfig) {
+        //throw an error if we got something like undefined or a primitive
+        if( typeof newConfig !== 'object' ){
+            throw new Error('IRCBot.updateConfig - newConfig was not an object.');
+        }
         
+        //update the internal config with the new properties
+        this.config = extend(true, this.config, newConfig);
     };
     
     start () {

--- a/tests/updateConfig.test.js
+++ b/tests/updateConfig.test.js
@@ -1,0 +1,61 @@
+var expect = require('chai').expect;
+var IRCBot = require('../src/ircbot.js');
+
+describe('IRCBot.updateConfig', function (){
+    var myBot;
+    beforeEach( () => {
+        myBot = new IRCBot();
+        myBot.config = {
+            test: 'test'
+        };
+    });
+    it('should accept an empty object and do nothing', () => {
+        myBot.updateConfig({});
+        
+        expect(myBot.config).to.deep.equal({
+            test: 'test'
+        });
+    });
+    
+    it('should throw an error if something other than an object is passed in', () => {
+        expect( () => {
+            myBot.updateConfig();
+        }).to.throw(Error);
+    });
+    
+    it('should add new properties to the bot config', () => {
+        myBot.updateConfig({
+            apple: 'orange'
+        });
+        
+        expect(myBot.config.apple).to.equal('orange');
+    });
+    
+    it('should add complex objects to the config', () => {
+        myBot.updateConfig({
+            fatObj: {
+                thisObject: 'should lose weight'
+            }
+        });
+        
+        expect(myBot.config.fatObj).to.deep.equal({
+            thisObject: 'should lose weight'
+        });
+    });
+    
+    it('should only update the properties in the new object', () => {
+        myBot.updateConfig({
+            banana: 'is a fruit, man'
+        });
+        
+        expect(myBot.config.test).to.equal('test');
+    });
+    
+    it('should allow overwriting existing properties', () => {
+        myBot.updateConfig({
+            test: 'newTest'
+        });
+        
+        expect(myBot.config.test).to.equal('newTest');
+    });
+});


### PR DESCRIPTION
- Added tests and functionality

I'm not sure if this is really necessary, my original thought was that using

```
myBot.updateConfig({
  newProp: 'value'
})
```

seemed a little nicer than

```
myBot.config = extend(true, myBot.config, {
  newProp: 'value'
})
```

it also gives us a way to add hooks to config updates for like hot reload or something later. Thoughts?
