### PR TITLE
Feature/use

### DIFF
--- a/src/ircbot.js
+++ b/src/ircbot.js
@@ -10,13 +10,13 @@ module.exports = class IRCBot {
         this._plugins = {};
     };
     
-    use (pluginName, pluginConstructor, injectedServices) {
+    use (pluginName, PluginConstructor, injectedServices) {
         //check for valid parameters
         if( typeof pluginName != 'string' ){
             throw new Error('IRCBot.use: pluginName was not a string, received '+(typeof pluginName));
         }
-        if( typeof pluginConstructor != 'function' ){
-            throw new Error('IRCBot.use: pluginConstructor was not a constructor function, received '+(typeof pluginConstructor));
+        if( typeof PluginConstructor != 'function' ){
+            throw new Error('IRCBot.use: PluginConstructor was not a constructor function, received '+(typeof PluginConstructor));
         }
         //check to see if the plugin is already registered
         if( this._plugins[pluginName] ){
@@ -35,9 +35,9 @@ module.exports = class IRCBot {
         }));
         
         //add a new instance of this plugin under the correct name
-        this._plugins[pluginName] = new (pluginConstructor.bind.apply(pluginConstructor, [pluginConstructor].concat(pluginArguments)));
+        this._plugins[pluginName] = new (PluginConstructor.bind.apply(PluginConstructor, [PluginConstructor].concat(pluginArguments)));
         //if the environment supported node 5.x.x, we could use the spread operator :(
-        /*this._plugins[pluginName] = new pluginConstructor(this, ...injectedServices.map((val) => {
+        /*this._plugins[pluginName] = new PluginConstructor(this, ...injectedServices.map((val) => {
             return this._plugins[val];
         }))*/
     };

--- a/src/ircbot.js
+++ b/src/ircbot.js
@@ -6,10 +6,40 @@ module.exports = class IRCBot {
         config = config || {};
         //eliminate reference issues
         this.config = extend(true, {}, config);
+        //init plugins container
+        this._plugins = {};
     };
     
-    use () {
+    use (pluginName, pluginConstructor, injectedServices) {
+        //check for valid parameters
+        if( typeof pluginName != 'string' ){
+            throw new Error('IRCBot.use: pluginName was not a string, received '+(typeof pluginName));
+        }
+        if( typeof pluginConstructor != 'function' ){
+            throw new Error('IRCBot.use: pluginConstructor was not a constructor function, received '+(typeof pluginConstructor));
+        }
+        //check to see if the plugin is already registered
+        if( this._plugins[pluginName] ){
+            throw new Error('IRCBot.use: Plugin \''+pluginName+'\' is already registered.');
+        }
+        //see if we should initialize the injectedServices array
+        injectedServices = injectedServices || [];
         
+        //create the constructor arguments as an array for apply
+        var pluginArguments = [this].concat(injectedServices.map((val) => {
+            //arrow function allows this to still be the bot instance. Hooray!
+            if( !this._plugins[val] ){
+                throw new Error('IRCBot.use: Plugin \''+val+'\' was injected before it was registered on the bot.');
+            }
+            return this._plugins[val];
+        }));
+        
+        //add a new instance of this plugin under the correct name
+        this._plugins[pluginName] = new (pluginConstructor.bind.apply(pluginConstructor, [pluginConstructor].concat(pluginArguments)));
+        //if the environment supported node 5.x.x, we could use the spread operator :(
+        /*this._plugins[pluginName] = new pluginConstructor(this, ...injectedServices.map((val) => {
+            return this._plugins[val];
+        }))*/
     };
     
     updateConfig () {

--- a/tests/use.test.js
+++ b/tests/use.test.js
@@ -19,10 +19,10 @@ describe('IRCBot.use', () => {
         
         it('should throw an error if the second argument is not a constructor', () => {
             "use strict";
-            class test {
+            class Test {
                 constructor(){};
             }; //typeof test == function
-            function alsoTest(){};
+            function AlsoTest(){};
             
             expect(() => {
                 myBot.use('1',undefined);
@@ -33,11 +33,11 @@ describe('IRCBot.use', () => {
             }).to.throw(Error);
             
             expect(() => {
-                myBot.use('3', test);
+                myBot.use('3', Test);
             }).to.not.throw(Error);
             
             expect(() => {
-                myBot.use('4', alsoTest);
+                myBot.use('4', AlsoTest);
             }).to.not.throw(Error);
         });
         
@@ -62,26 +62,26 @@ describe('IRCBot.use', () => {
             }).to.not.throw(Error);
         });
         it('should send the bot as the first parameter to the new plugin constructor without the _plugins property exposed', () => {
-            var somePlugin = function (bot){
+            var SomePlugin = function (bot){
                 expect(bot === myBot).to.be.true;
             };
-            myBot.use('test', somePlugin);
+            myBot.use('test', SomePlugin);
         });
         it('should send injected plugins to the constructor of the new plugin', () => {
             "use strict";
-            class firstPlugin {
+            class FirstPlugin {
                 constructor (){};
             };
             
-            class secondPlugin {
+            class SecondPlugin {
                 constructor (bot, dep){
-                    expect(dep instanceof firstPlugin).to.be.true;
+                    expect(dep instanceof FirstPlugin).to.be.true;
                 };
             };
             
-            myBot.use('firstPlugin', firstPlugin);
+            myBot.use('firstPlugin', FirstPlugin);
             //run the expectation constructor
-            myBot.use('secondPlugin', secondPlugin, ['firstPlugin']);
+            myBot.use('secondPlugin', FirstPlugin, ['firstPlugin']);
         });
     });
 });

--- a/tests/use.test.js
+++ b/tests/use.test.js
@@ -1,0 +1,87 @@
+var expect = require('chai').expect;
+var IRCBot = require('../src/ircbot.js');
+
+describe('IRCBot.use', () => {
+    var myBot;
+    beforeEach(() =>{
+        myBot = new IRCBot({});
+    });
+    describe('Exceptions', () => {
+        it('should throw an error if the first argument is not a string', () => {
+            expect(() => {
+                myBot.use();
+            }).to.throw(Error);
+            
+            expect(() =>{
+                myBot.use({});
+            }).to.throw(Error);
+        });
+        
+        it('should throw an error if the second argument is not a constructor', () => {
+            "use strict";
+            class test {
+                constructor(){};
+            }; //typeof test == function
+            function alsoTest(){};
+            
+            expect(() => {
+                myBot.use('1',undefined);
+            }).to.throw(Error);
+            
+            expect(() => {
+                myBot.use('2', {});
+            }).to.throw(Error);
+            
+            expect(() => {
+                myBot.use('3', test);
+            }).to.not.throw(Error);
+            
+            expect(() => {
+                myBot.use('4', alsoTest);
+            }).to.not.throw(Error);
+        });
+        
+        it('should throw an error if the plugin is already registered', () => {
+            myBot.use('test', function (){});
+            expect(() => {
+                myBot.use('test', function (){});
+            }).to.throw(Error);
+        });
+        
+        it('should throw an error if a dependency is injected before it is registered', () => {
+            expect(() => {
+                myBot.use('test', function (){}, ['someDep']);
+            }).to.throw(Error);
+        });
+    });
+    
+    describe('Dependency Injection', () => {
+        it('should allow no parameter for injection', () => {
+            expect(() => {
+                myBot.use('firstPlugin', function (){}, undefined);
+            }).to.not.throw(Error);
+        });
+        it('should send the bot as the first parameter to the new plugin constructor without the _plugins property exposed', () => {
+            var somePlugin = function (bot){
+                expect(bot === myBot).to.be.true;
+            };
+            myBot.use('test', somePlugin);
+        });
+        it('should send injected plugins to the constructor of the new plugin', () => {
+            "use strict";
+            class firstPlugin {
+                constructor (){};
+            };
+            
+            class secondPlugin {
+                constructor (bot, dep){
+                    expect(dep instanceof firstPlugin).to.be.true;
+                };
+            };
+            
+            myBot.use('firstPlugin', firstPlugin);
+            //run the expectation constructor
+            myBot.use('secondPlugin', secondPlugin, ['firstPlugin']);
+        });
+    });
+});


### PR DESCRIPTION
**Question**: Should we attempt to hide/remove the _plugins property of the bot before we send it to the plugin constructor, since we're injected all required services anyway? Not sure that's worth the effort. Without that, the injection is just sugar to replace `var somePlugin = bot._plugins['somePlugin']`. I'm fine with that, but wanted to mention it.
